### PR TITLE
Make installation via docker just need to copy&paste.

### DIFF
--- a/documentation/docs/installation/docker.md
+++ b/documentation/docs/installation/docker.md
@@ -7,6 +7,8 @@ Docker images of `hummingbot` are available on Docker Hub at [coinalpha/hummingb
 ## Create new instance of `hummingbot`
 
 ``` bash tab="Terminal: Start hummingbot with Docker"
+export NAME=myhummingbot && \
+export TAG=latest && \
 docker run -it \
 --name $NAME \
 -v "$PWD"/conf/:/conf/ \


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [N/A] Your code builds clean without any errors or warnings
- [N/A] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: N/A
- Related Clubhouse Story: N/A


**A description of the changes proposed in the pull request**:
Currently the command provided to install HB via docker is not copy&paste to install. We should reduce friction for users to adopt as much as possible.
